### PR TITLE
Phase 2: Shared Repositories & Hilt Bindings

### DIFF
--- a/app/src/main/java/com/driverwallet/app/core/di/RepositoryModule.kt
+++ b/app/src/main/java/com/driverwallet/app/core/di/RepositoryModule.kt
@@ -1,0 +1,36 @@
+package com.driverwallet.app.core.di
+
+import com.driverwallet.app.feature.debt.data.DebtRepositoryImpl
+import com.driverwallet.app.feature.debt.domain.DebtRepository
+import com.driverwallet.app.feature.settings.data.SettingsRepositoryImpl
+import com.driverwallet.app.feature.settings.domain.SettingsRepository
+import com.driverwallet.app.shared.data.TransactionRepositoryImpl
+import com.driverwallet.app.shared.data.repository.TransactionRepository
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class RepositoryModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindTransactionRepository(
+        impl: TransactionRepositoryImpl,
+    ): TransactionRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindDebtRepository(
+        impl: DebtRepositoryImpl,
+    ): DebtRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindSettingsRepository(
+        impl: SettingsRepositoryImpl,
+    ): SettingsRepository
+}

--- a/app/src/main/java/com/driverwallet/app/feature/debt/data/DebtRepositoryImpl.kt
+++ b/app/src/main/java/com/driverwallet/app/feature/debt/data/DebtRepositoryImpl.kt
@@ -1,0 +1,110 @@
+package com.driverwallet.app.feature.debt.data
+
+import androidx.room.withTransaction
+import com.driverwallet.app.core.database.AppDatabase
+import com.driverwallet.app.core.model.TransactionType
+import com.driverwallet.app.core.model.nowJakarta
+import com.driverwallet.app.core.util.UuidGenerator
+import com.driverwallet.app.feature.debt.data.dao.DebtDao
+import com.driverwallet.app.feature.debt.data.dao.DebtScheduleDao
+import com.driverwallet.app.feature.debt.data.dao.UpcomingDueTuple
+import com.driverwallet.app.feature.debt.data.entity.DebtEntity
+import com.driverwallet.app.feature.debt.data.entity.DebtScheduleEntity
+import com.driverwallet.app.feature.debt.domain.DebtRepository
+import com.driverwallet.app.feature.debt.domain.DebtWithScheduleInfo
+import com.driverwallet.app.shared.data.dao.TransactionDao
+import com.driverwallet.app.shared.data.entity.TransactionEntity
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import java.time.format.DateTimeFormatter
+import javax.inject.Inject
+
+class DebtRepositoryImpl @Inject constructor(
+    private val database: AppDatabase,
+    private val debtDao: DebtDao,
+    private val debtScheduleDao: DebtScheduleDao,
+    private val transactionDao: TransactionDao,
+) : DebtRepository {
+
+    override fun observeActiveDebtsWithSchedule(): Flow<List<DebtWithScheduleInfo>> =
+        debtDao.observeActiveDebts().map { debts ->
+            debts.map { debt ->
+                DebtWithScheduleInfo(
+                    debt = debt,
+                    nextSchedule = debtScheduleDao.getNextUnpaid(debt.id),
+                    paidCount = debtScheduleDao.countPaid(debt.id),
+                    totalCount = debt.installmentCount,
+                )
+            }
+        }
+
+    override fun observeTotalRemaining(): Flow<Long> =
+        debtDao.observeTotalRemaining()
+
+    override suspend fun getById(id: String): DebtEntity? =
+        debtDao.getById(id)
+
+    override suspend fun saveDebt(debt: DebtEntity, schedules: List<DebtScheduleEntity>) {
+        database.withTransaction {
+            debtDao.insert(debt)
+            debtScheduleDao.insertAll(schedules)
+        }
+    }
+
+    /**
+     * Atomic 4-step payment:
+     * 1. Update remaining amount on debt
+     * 2. Mark schedule as paid
+     * 3. Insert expense transaction (category = debt_payment)
+     * 4. Auto-complete debt if remaining = 0
+     */
+    override suspend fun payInstallment(
+        debtId: String,
+        scheduleId: String,
+        amount: Long,
+    ) {
+        database.withTransaction {
+            val now = nowJakarta().format(DateTimeFormatter.ISO_ZONED_DATE_TIME)
+
+            // 1. Update remaining
+            val debt = debtDao.getById(debtId) ?: return@withTransaction
+            val newRemaining = (debt.remainingAmount - amount).coerceAtLeast(0)
+            debtDao.updateRemaining(debtId, newRemaining, now)
+
+            // 2. Mark schedule paid
+            debtScheduleDao.markAsPaid(scheduleId, now, amount, now)
+
+            // 3. Insert expense transaction
+            transactionDao.insert(
+                TransactionEntity(
+                    id = UuidGenerator.generate(),
+                    type = TransactionType.EXPENSE.name,
+                    category = "debt_payment",
+                    amount = amount,
+                    note = "Bayar cicilan ${debt.name}",
+                    debtId = debtId,
+                    createdAt = now,
+                    updatedAt = now,
+                ),
+            )
+
+            // 4. Auto-complete if fully paid
+            if (newRemaining == 0L) {
+                debtDao.updateStatus(debtId, "completed", now)
+            }
+        }
+    }
+
+    override suspend fun softDelete(debtId: String) {
+        val now = nowJakarta().format(DateTimeFormatter.ISO_ZONED_DATE_TIME)
+        debtDao.softDelete(debtId, now)
+    }
+
+    override suspend fun getUpcomingDue(maxDate: String): List<UpcomingDueTuple> =
+        debtScheduleDao.getUpcomingDue(maxDate)
+
+    override suspend fun markOverdueSchedules(today: String) {
+        val now = nowJakarta().format(DateTimeFormatter.ISO_ZONED_DATE_TIME)
+        debtScheduleDao.markOverdueSchedules(today, now)
+    }
+}

--- a/app/src/main/java/com/driverwallet/app/feature/debt/domain/DebtRepository.kt
+++ b/app/src/main/java/com/driverwallet/app/feature/debt/domain/DebtRepository.kt
@@ -1,0 +1,30 @@
+package com.driverwallet.app.feature.debt.domain
+
+import com.driverwallet.app.feature.debt.data.dao.UpcomingDueTuple
+import com.driverwallet.app.feature.debt.data.entity.DebtEntity
+import com.driverwallet.app.feature.debt.data.entity.DebtScheduleEntity
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Aggregated debt info combining debt with its schedule progress.
+ */
+data class DebtWithScheduleInfo(
+    val debt: DebtEntity,
+    val nextSchedule: DebtScheduleEntity?,
+    val paidCount: Int,
+    val totalCount: Int,
+) {
+    val percentage: Float
+        get() = if (totalCount > 0) paidCount.toFloat() / totalCount else 0f
+}
+
+interface DebtRepository {
+    fun observeActiveDebtsWithSchedule(): Flow<List<DebtWithScheduleInfo>>
+    fun observeTotalRemaining(): Flow<Long>
+    suspend fun getById(id: String): DebtEntity?
+    suspend fun saveDebt(debt: DebtEntity, schedules: List<DebtScheduleEntity>)
+    suspend fun payInstallment(debtId: String, scheduleId: String, amount: Long)
+    suspend fun softDelete(debtId: String)
+    suspend fun getUpcomingDue(maxDate: String): List<UpcomingDueTuple>
+    suspend fun markOverdueSchedules(today: String)
+}

--- a/app/src/main/java/com/driverwallet/app/feature/settings/data/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/driverwallet/app/feature/settings/data/SettingsRepositoryImpl.kt
@@ -1,0 +1,70 @@
+package com.driverwallet.app.feature.settings.data
+
+import com.driverwallet.app.feature.settings.data.dao.DailyBudgetDao
+import com.driverwallet.app.feature.settings.data.dao.DailyExpenseDao
+import com.driverwallet.app.feature.settings.data.dao.MonthlyExpenseDao
+import com.driverwallet.app.feature.settings.data.dao.SettingsDao
+import com.driverwallet.app.feature.settings.data.entity.DailyBudgetEntity
+import com.driverwallet.app.feature.settings.data.entity.DailyExpenseEntity
+import com.driverwallet.app.feature.settings.data.entity.MonthlyExpenseEntity
+import com.driverwallet.app.feature.settings.data.entity.SettingsEntity
+import com.driverwallet.app.feature.settings.domain.SettingsRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class SettingsRepositoryImpl @Inject constructor(
+    private val dailyBudgetDao: DailyBudgetDao,
+    private val monthlyExpenseDao: MonthlyExpenseDao,
+    private val dailyExpenseDao: DailyExpenseDao,
+    private val settingsDao: SettingsDao,
+) : SettingsRepository {
+
+    // Daily Budgets
+    override fun observeDailyBudgets(): Flow<List<DailyBudgetEntity>> =
+        dailyBudgetDao.observeAll()
+
+    override suspend fun getDailyBudgets(): List<DailyBudgetEntity> =
+        dailyBudgetDao.getAll()
+
+    override suspend fun saveBudgets(budgets: List<DailyBudgetEntity>) =
+        dailyBudgetDao.upsertAll(budgets)
+
+    override suspend fun getTotalDailyBudget(): Long =
+        dailyBudgetDao.getTotalBudget()
+
+    // Monthly Expenses
+    override fun observeMonthlyExpenses(): Flow<List<MonthlyExpenseEntity>> =
+        monthlyExpenseDao.observeAll()
+
+    override suspend fun saveMonthlyExpense(expense: MonthlyExpenseEntity) =
+        monthlyExpenseDao.upsert(expense)
+
+    override suspend fun deleteMonthlyExpense(id: Long) =
+        monthlyExpenseDao.softDelete(id)
+
+    override suspend fun getTotalMonthlyExpense(): Long =
+        monthlyExpenseDao.getTotalAmount()
+
+    // Daily Expenses
+    override fun observeDailyExpenses(): Flow<List<DailyExpenseEntity>> =
+        dailyExpenseDao.observeAll()
+
+    override suspend fun saveDailyExpense(expense: DailyExpenseEntity) =
+        dailyExpenseDao.upsert(expense)
+
+    override suspend fun deleteDailyExpense(id: Long) =
+        dailyExpenseDao.softDelete(id)
+
+    override suspend fun getTotalDailyExpense(): Long =
+        dailyExpenseDao.getTotalAmount()
+
+    // Settings key-value
+    override suspend fun getSetting(key: String): String? =
+        settingsDao.getValue(key)
+
+    override fun observeSetting(key: String): Flow<String?> =
+        settingsDao.observeValue(key)
+
+    override suspend fun saveSetting(key: String, value: String) =
+        settingsDao.upsert(SettingsEntity(key, value))
+}

--- a/app/src/main/java/com/driverwallet/app/feature/settings/domain/SettingsRepository.kt
+++ b/app/src/main/java/com/driverwallet/app/feature/settings/domain/SettingsRepository.kt
@@ -1,0 +1,31 @@
+package com.driverwallet.app.feature.settings.domain
+
+import com.driverwallet.app.feature.settings.data.entity.DailyBudgetEntity
+import com.driverwallet.app.feature.settings.data.entity.DailyExpenseEntity
+import com.driverwallet.app.feature.settings.data.entity.MonthlyExpenseEntity
+import kotlinx.coroutines.flow.Flow
+
+interface SettingsRepository {
+    // Daily Budgets
+    fun observeDailyBudgets(): Flow<List<DailyBudgetEntity>>
+    suspend fun getDailyBudgets(): List<DailyBudgetEntity>
+    suspend fun saveBudgets(budgets: List<DailyBudgetEntity>)
+    suspend fun getTotalDailyBudget(): Long
+
+    // Monthly Expenses
+    fun observeMonthlyExpenses(): Flow<List<MonthlyExpenseEntity>>
+    suspend fun saveMonthlyExpense(expense: MonthlyExpenseEntity)
+    suspend fun deleteMonthlyExpense(id: Long)
+    suspend fun getTotalMonthlyExpense(): Long
+
+    // Daily Expenses
+    fun observeDailyExpenses(): Flow<List<DailyExpenseEntity>>
+    suspend fun saveDailyExpense(expense: DailyExpenseEntity)
+    suspend fun deleteDailyExpense(id: Long)
+    suspend fun getTotalDailyExpense(): Long
+
+    // Settings key-value
+    suspend fun getSetting(key: String): String?
+    fun observeSetting(key: String): Flow<String?>
+    suspend fun saveSetting(key: String, value: String)
+}

--- a/app/src/main/java/com/driverwallet/app/shared/data/TransactionRepositoryImpl.kt
+++ b/app/src/main/java/com/driverwallet/app/shared/data/TransactionRepositoryImpl.kt
@@ -1,0 +1,115 @@
+package com.driverwallet.app.shared.data
+
+import com.driverwallet.app.core.model.Categories
+import com.driverwallet.app.core.model.TransactionType
+import com.driverwallet.app.core.model.nowJakarta
+import com.driverwallet.app.core.model.todayJakarta
+import com.driverwallet.app.feature.dashboard.domain.model.TodaySummary
+import com.driverwallet.app.feature.report.domain.model.CategorySummary
+import com.driverwallet.app.feature.report.domain.model.DailySummary
+import com.driverwallet.app.shared.data.dao.TransactionDao
+import com.driverwallet.app.shared.data.mapper.toDomain
+import com.driverwallet.app.shared.data.mapper.toEntity
+import com.driverwallet.app.shared.data.repository.TransactionRepository
+import com.driverwallet.app.shared.domain.model.Transaction
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import java.time.format.DateTimeFormatter
+import javax.inject.Inject
+
+class TransactionRepositoryImpl @Inject constructor(
+    private val transactionDao: TransactionDao,
+) : TransactionRepository {
+
+    override fun observeTodayTransactions(): Flow<List<Transaction>> {
+        val todayPrefix = todayJakarta().toString()
+        return transactionDao.observeByDate(todayPrefix).map { entities ->
+            entities.map { it.toDomain() }
+        }
+    }
+
+    override suspend fun getTodaySummary(todayPrefix: String): TodaySummary {
+        val tuples = transactionDao.getTodaySummary(todayPrefix)
+        var income = 0L
+        var totalExpense = 0L
+        tuples.forEach { tuple ->
+            when (tuple.type) {
+                TransactionType.INCOME.name -> income = tuple.total
+                TransactionType.EXPENSE.name -> totalExpense = tuple.total
+            }
+        }
+        // Separate debt_payment from regular expense
+        val debtPayment = transactionDao.getBudgetSpentToday(
+            todayPrefix,
+            listOf(Categories.DEBT_PAYMENT.key),
+        )
+        return TodaySummary(
+            income = income,
+            expense = totalExpense - debtPayment,
+            debtPayment = debtPayment,
+        )
+    }
+
+    override suspend fun insert(transaction: Transaction) {
+        transactionDao.insert(transaction.toEntity())
+    }
+
+    override suspend fun getDailySummary(
+        startDate: String,
+        endDate: String,
+    ): List<DailySummary> {
+        val tuples = transactionDao.getDailySummary(startDate, endDate)
+        return tuples.groupBy { it.date }.map { (date, entries) ->
+            var income = 0L
+            var expense = 0L
+            var count = 0
+            entries.forEach { entry ->
+                count += entry.count
+                when (entry.type) {
+                    TransactionType.INCOME.name -> income = entry.total
+                    TransactionType.EXPENSE.name -> expense = entry.total
+                }
+            }
+            DailySummary(
+                date = date,
+                income = income,
+                expense = expense,
+                transactionCount = count,
+            )
+        }
+    }
+
+    override suspend fun getCategorySummary(
+        startDate: String,
+        endDate: String,
+    ): List<CategorySummary> {
+        val tuples = transactionDao.getCategorySummary(startDate, endDate)
+        val totalAmount = tuples.sumOf { it.total }.coerceAtLeast(1)
+        return tuples.map { tuple ->
+            val category = Categories.fromKey(tuple.category)
+            CategorySummary(
+                categoryKey = tuple.category,
+                categoryLabel = category?.label ?: tuple.category,
+                total = tuple.total,
+                count = tuple.count,
+                percentage = tuple.total.toFloat() / totalAmount,
+            )
+        }
+    }
+
+    override suspend fun getByDateRange(
+        startDate: String,
+        endDate: String,
+    ): List<Transaction> =
+        transactionDao.getByDateRange(startDate, endDate).map { it.toDomain() }
+
+    override suspend fun getBudgetSpentToday(
+        todayPrefix: String,
+        categories: List<String>,
+    ): Long = transactionDao.getBudgetSpentToday(todayPrefix, categories)
+
+    override suspend fun softDelete(id: String) {
+        val now = nowJakarta().format(DateTimeFormatter.ISO_ZONED_DATE_TIME)
+        transactionDao.softDelete(id, now)
+    }
+}

--- a/app/src/main/java/com/driverwallet/app/shared/data/repository/TransactionRepository.kt
+++ b/app/src/main/java/com/driverwallet/app/shared/data/repository/TransactionRepository.kt
@@ -1,0 +1,18 @@
+package com.driverwallet.app.shared.data.repository
+
+import com.driverwallet.app.feature.dashboard.domain.model.TodaySummary
+import com.driverwallet.app.feature.report.domain.model.CategorySummary
+import com.driverwallet.app.feature.report.domain.model.DailySummary
+import com.driverwallet.app.shared.domain.model.Transaction
+import kotlinx.coroutines.flow.Flow
+
+interface TransactionRepository {
+    fun observeTodayTransactions(): Flow<List<Transaction>>
+    suspend fun getTodaySummary(todayPrefix: String): TodaySummary
+    suspend fun insert(transaction: Transaction)
+    suspend fun getDailySummary(startDate: String, endDate: String): List<DailySummary>
+    suspend fun getCategorySummary(startDate: String, endDate: String): List<CategorySummary>
+    suspend fun getByDateRange(startDate: String, endDate: String): List<Transaction>
+    suspend fun getBudgetSpentToday(todayPrefix: String, categories: List<String>): Long
+    suspend fun softDelete(id: String)
+}


### PR DESCRIPTION
## 🎯 Tujuan
Bangun Repository interfaces (domain) dan implementations (data) yang menjembatani UseCase dengan Room/DataStore.

**Closes #4**

---

## 📦 Files (7)

### Repository Interfaces (Domain Contracts)
| Repository | Package | Methods |
|---|---|---|
| `TransactionRepository` | `shared.data.repository` | `observeTodayTransactions`, `getTodaySummary`, `insert`, `getDailySummary`, `getCategorySummary`, `getByDateRange`, `getBudgetSpentToday`, `softDelete` |
| `DebtRepository` | `feature.debt.domain` | `observeActiveDebtsWithSchedule`, `saveDebt`, `payInstallment` (atomic 4-step), `softDelete`, `getUpcomingDue`, `markOverdueSchedules` |
| `SettingsRepository` | `feature.settings.domain` | budgets CRUD, monthly/daily expenses CRUD, settings key-value |

### Repository Implementations
| Impl | Key Logic |
|---|---|
| `TransactionRepositoryImpl` | Entity→Domain mapping, separates `debt_payment` from regular expense in TodaySummary, pivots DailySummaryTuple→DailySummary |
| `DebtRepositoryImpl` | `database.withTransaction{}` atomic payment: (1) update remaining, (2) mark paid, (3) insert transaction, (4) auto-complete |
| `SettingsRepositoryImpl` | Coordinates 4 DAOs (DailyBudget, MonthlyExpense, DailyExpense, Settings) |

### Hilt DI
| Module | Scope | Bindings |
|---|---|---|
| `RepositoryModule` | `SingletonComponent` | `@Binds` × 3 repos |

---

## 🔑 Key Design Decisions

### Atomic `payInstallment`
```
database.withTransaction {
  1. debtDao.updateRemaining()
  2. scheduleDao.markAsPaid()
  3. transactionDao.insert(expense)
  4. if (remaining == 0) debtDao.updateStatus("completed")
}
```
If any step fails, ALL roll back.

### TodaySummary debt_payment split
`expense` field excludes debt payments. `debtPayment` tracked separately.
`profit = income - expense - debtPayment` (matches AD_01 spec).

### DebtWithScheduleInfo
Aggregated model combining DebtEntity + next unpaid schedule + paid/total count + percentage. Used by Phase 5 UI.

---

## ✅ Checklist
- [x] 3 repository interfaces with full method signatures
- [x] 3 implementations with `@Inject` constructor
- [x] `payInstallment` uses `withTransaction{}` for atomicity
- [x] `TransactionRepositoryImpl` separates debt_payment from expense
- [x] `SettingsRepositoryImpl` coordinates 4 DAOs
- [x] `RepositoryModule` binds all 3 as Singleton
- [x] All Hilt dependency graph should resolve