### PR TITLE
Phase 3: Feature — Quick Input (F02) ⚡

### DIFF
--- a/app/src/main/java/com/driverwallet/app/core/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/driverwallet/app/core/ui/navigation/AppNavigation.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import com.driverwallet.app.feature.input.ui.QuickInputScreen
 
 @Composable
 fun AppNavigation(modifier: Modifier = Modifier) {
@@ -31,12 +32,27 @@ fun AppNavigation(modifier: Modifier = Modifier) {
             modifier = Modifier
                 .fillMaxSize()
                 .padding(innerPadding),
-            contentAlignment = Alignment.Center,
         ) {
-            Text(
-                text = bottomNavItems[selectedTab].label,
-                style = MaterialTheme.typography.headlineLarge,
-            )
+            when (selectedTab) {
+                0 -> PlaceholderScreen("Beranda")
+                1 -> QuickInputScreen()
+                2 -> PlaceholderScreen("Hutang")
+                3 -> PlaceholderScreen("Laporan")
+                4 -> PlaceholderScreen("Setelan")
+            }
         }
+    }
+}
+
+@Composable
+private fun PlaceholderScreen(title: String) {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.headlineLarge,
+        )
     }
 }

--- a/app/src/main/java/com/driverwallet/app/feature/input/domain/SaveTransactionUseCase.kt
+++ b/app/src/main/java/com/driverwallet/app/feature/input/domain/SaveTransactionUseCase.kt
@@ -1,0 +1,31 @@
+package com.driverwallet.app.feature.input.domain
+
+import com.driverwallet.app.shared.data.repository.TransactionRepository
+import com.driverwallet.app.shared.domain.model.Transaction
+import javax.inject.Inject
+
+class SaveTransactionUseCase @Inject constructor(
+    private val repository: TransactionRepository,
+) {
+    suspend operator fun invoke(transaction: Transaction): Result<Unit> {
+        if (transaction.amount <= 0) {
+            return Result.failure(IllegalArgumentException("Jumlah harus lebih dari 0"))
+        }
+        if (transaction.amount > MAX_AMOUNT) {
+            return Result.failure(IllegalArgumentException("Jumlah maksimal Rp 999.999.999"))
+        }
+        if (transaction.note.length > MAX_NOTE_LENGTH) {
+            return Result.failure(IllegalArgumentException("Catatan maksimal 100 karakter"))
+        }
+        if (transaction.category == null) {
+            return Result.failure(IllegalArgumentException("Pilih kategori"))
+        }
+        return runCatching { repository.insert(transaction) }
+    }
+
+    companion object {
+        const val MAX_AMOUNT = 999_999_999L
+        const val MAX_NOTE_LENGTH = 100
+        const val MAX_DIGITS = 9
+    }
+}

--- a/app/src/main/java/com/driverwallet/app/feature/input/ui/QuickInputScreen.kt
+++ b/app/src/main/java/com/driverwallet/app/feature/input/ui/QuickInputScreen.kt
@@ -1,0 +1,112 @@
+package com.driverwallet.app.feature.input.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.driverwallet.app.core.ui.component.LoadingIndicator
+import com.driverwallet.app.core.ui.navigation.GlobalUiEvent
+import com.driverwallet.app.feature.input.ui.component.AmountDisplay
+import com.driverwallet.app.feature.input.ui.component.CategoryGrid
+import com.driverwallet.app.feature.input.ui.component.NoteInput
+import com.driverwallet.app.feature.input.ui.component.NumberPad
+import com.driverwallet.app.feature.input.ui.component.PresetButtons
+import com.driverwallet.app.feature.input.ui.component.SaveButton
+import com.driverwallet.app.feature.input.ui.component.TypeToggle
+
+@Composable
+fun QuickInputScreen(
+    viewModel: QuickInputViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(Unit) {
+        viewModel.uiEvent.collect { event ->
+            when (event) {
+                is GlobalUiEvent.ShowSnackbar -> {
+                    snackbarHostState.showSnackbar(event.message)
+                }
+                else -> Unit
+            }
+        }
+    }
+
+    Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+    ) { innerPadding ->
+        when (val state = uiState) {
+            is QuickInputUiState.Loading -> LoadingIndicator()
+            is QuickInputUiState.Ready -> {
+                QuickInputContent(
+                    state = state,
+                    onAction = viewModel::onAction,
+                    modifier = Modifier.padding(innerPadding),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun QuickInputContent(
+    state: QuickInputUiState.Ready,
+    onAction: (QuickInputUiAction) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 16.dp)
+            .verticalScroll(rememberScrollState()),
+    ) {
+        Spacer(modifier = Modifier.height(16.dp))
+        TypeToggle(
+            selectedType = state.type,
+            onTypeSelected = { onAction(QuickInputUiAction.SwitchType(it)) },
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+        AmountDisplay(displayAmount = state.displayAmount)
+        Spacer(modifier = Modifier.height(16.dp))
+        PresetButtons(
+            onPresetSelected = { onAction(QuickInputUiAction.AddPreset(it)) },
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        NumberPad(
+            onDigit = { onAction(QuickInputUiAction.AppendDigit(it)) },
+            onBackspace = { onAction(QuickInputUiAction.Backspace) },
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+        CategoryGrid(
+            categories = state.categories,
+            selectedCategory = state.selectedCategory,
+            onCategorySelected = { onAction(QuickInputUiAction.SelectCategory(it)) },
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        NoteInput(
+            note = state.note,
+            onNoteChange = { onAction(QuickInputUiAction.UpdateNote(it)) },
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+        SaveButton(
+            canSave = state.canSave,
+            isSaving = state.isSaving,
+            onClick = { onAction(QuickInputUiAction.Save) },
+        )
+        Spacer(modifier = Modifier.height(32.dp))
+    }
+}

--- a/app/src/main/java/com/driverwallet/app/feature/input/ui/QuickInputUiAction.kt
+++ b/app/src/main/java/com/driverwallet/app/feature/input/ui/QuickInputUiAction.kt
@@ -1,0 +1,14 @@
+package com.driverwallet.app.feature.input.ui
+
+import com.driverwallet.app.core.model.Category
+import com.driverwallet.app.core.model.TransactionType
+
+sealed interface QuickInputUiAction {
+    data class SwitchType(val type: TransactionType) : QuickInputUiAction
+    data class SelectCategory(val category: Category) : QuickInputUiAction
+    data class AppendDigit(val digit: String) : QuickInputUiAction
+    data object Backspace : QuickInputUiAction
+    data class AddPreset(val amount: Long) : QuickInputUiAction
+    data class UpdateNote(val note: String) : QuickInputUiAction
+    data object Save : QuickInputUiAction
+}

--- a/app/src/main/java/com/driverwallet/app/feature/input/ui/QuickInputUiState.kt
+++ b/app/src/main/java/com/driverwallet/app/feature/input/ui/QuickInputUiState.kt
@@ -1,0 +1,20 @@
+package com.driverwallet.app.feature.input.ui
+
+import com.driverwallet.app.core.model.Category
+import com.driverwallet.app.core.model.TransactionType
+
+sealed interface QuickInputUiState {
+    data object Loading : QuickInputUiState
+
+    data class Ready(
+        val type: TransactionType = TransactionType.INCOME,
+        val amount: Long = 0L,
+        val displayAmount: String = "0",
+        val selectedCategory: Category? = null,
+        val categories: List<Category> = emptyList(),
+        val note: String = "",
+        val isSaving: Boolean = false,
+    ) : QuickInputUiState {
+        val canSave: Boolean get() = amount > 0 && selectedCategory != null && !isSaving
+    }
+}

--- a/app/src/main/java/com/driverwallet/app/feature/input/ui/QuickInputViewModel.kt
+++ b/app/src/main/java/com/driverwallet/app/feature/input/ui/QuickInputViewModel.kt
@@ -1,0 +1,143 @@
+package com.driverwallet.app.feature.input.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.driverwallet.app.core.model.Categories
+import com.driverwallet.app.core.model.TransactionType
+import com.driverwallet.app.core.ui.navigation.GlobalUiEvent
+import com.driverwallet.app.core.util.CurrencyFormatter
+import com.driverwallet.app.feature.input.domain.SaveTransactionUseCase
+import com.driverwallet.app.shared.domain.model.Transaction
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class QuickInputViewModel @Inject constructor(
+    private val saveTransactionUseCase: SaveTransactionUseCase,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<QuickInputUiState>(
+        QuickInputUiState.Ready(
+            type = TransactionType.INCOME,
+            categories = Categories.incomeCategories,
+        ),
+    )
+    val uiState: StateFlow<QuickInputUiState> = _uiState.asStateFlow()
+
+    private val _uiEvent = MutableSharedFlow<GlobalUiEvent>()
+    val uiEvent = _uiEvent.asSharedFlow()
+
+    private var amountString = ""
+
+    fun onAction(action: QuickInputUiAction) {
+        val current = _uiState.value as? QuickInputUiState.Ready ?: return
+        when (action) {
+            is QuickInputUiAction.SwitchType -> switchType(action.type, current)
+            is QuickInputUiAction.SelectCategory -> selectCategory(action.category, current)
+            is QuickInputUiAction.AppendDigit -> appendDigit(action.digit, current)
+            is QuickInputUiAction.Backspace -> backspace(current)
+            is QuickInputUiAction.AddPreset -> addPreset(action.amount, current)
+            is QuickInputUiAction.UpdateNote -> updateNote(action.note, current)
+            is QuickInputUiAction.Save -> save(current)
+        }
+    }
+
+    private fun switchType(type: TransactionType, current: QuickInputUiState.Ready) {
+        val categories = when (type) {
+            TransactionType.INCOME -> Categories.incomeCategories
+            TransactionType.EXPENSE -> Categories.expenseCategories
+        }
+        _uiState.value = current.copy(
+            type = type,
+            categories = categories,
+            selectedCategory = null,
+        )
+    }
+
+    private fun selectCategory(category: com.driverwallet.app.core.model.Category, current: QuickInputUiState.Ready) {
+        _uiState.value = current.copy(selectedCategory = category)
+    }
+
+    private fun appendDigit(digit: String, current: QuickInputUiState.Ready) {
+        val newAmountString = amountString + digit
+        if (newAmountString.length > SaveTransactionUseCase.MAX_DIGITS) return
+        amountString = newAmountString
+        updateAmount(current)
+    }
+
+    private fun backspace(current: QuickInputUiState.Ready) {
+        if (amountString.isEmpty()) return
+        amountString = amountString.dropLast(1)
+        updateAmount(current)
+    }
+
+    private fun addPreset(presetAmount: Long, current: QuickInputUiState.Ready) {
+        val newAmount = current.amount + presetAmount
+        if (newAmount > SaveTransactionUseCase.MAX_AMOUNT) return
+        amountString = newAmount.toString()
+        updateAmount(current)
+    }
+
+    private fun updateAmount(current: QuickInputUiState.Ready) {
+        val amount = amountString.toLongOrNull() ?: 0L
+        _uiState.value = current.copy(
+            amount = amount,
+            displayAmount = if (amount == 0L) "0" else CurrencyFormatter.format(amount),
+        )
+    }
+
+    private fun updateNote(note: String, current: QuickInputUiState.Ready) {
+        if (note.length > SaveTransactionUseCase.MAX_NOTE_LENGTH) return
+        _uiState.value = current.copy(note = note)
+    }
+
+    private fun save(current: QuickInputUiState.Ready) {
+        if (!current.canSave) return
+        viewModelScope.launch {
+            _uiState.value = current.copy(isSaving = true)
+            val transaction = Transaction(
+                type = current.type,
+                category = current.selectedCategory,
+                amount = current.amount,
+                note = current.note,
+            )
+            saveTransactionUseCase(transaction)
+                .onSuccess {
+                    val typeLabel = when (current.type) {
+                        TransactionType.INCOME -> "Pemasukan"
+                        TransactionType.EXPENSE -> "Pengeluaran"
+                    }
+                    _uiEvent.emit(
+                        GlobalUiEvent.ShowSnackbar(
+                            "$typeLabel Rp ${CurrencyFormatter.format(current.amount)} tersimpan",
+                        ),
+                    )
+                    resetForm()
+                }
+                .onFailure { error ->
+                    _uiEvent.emit(
+                        GlobalUiEvent.ShowSnackbar(error.message ?: "Gagal menyimpan"),
+                    )
+                    _uiState.value = current.copy(isSaving = false)
+                }
+        }
+    }
+
+    private fun resetForm() {
+        amountString = ""
+        val currentState = _uiState.value as? QuickInputUiState.Ready ?: return
+        _uiState.value = currentState.copy(
+            amount = 0L,
+            displayAmount = "0",
+            selectedCategory = null,
+            note = "",
+            isSaving = false,
+        )
+    }
+}

--- a/app/src/main/java/com/driverwallet/app/feature/input/ui/component/AmountDisplay.kt
+++ b/app/src/main/java/com/driverwallet/app/feature/input/ui/component/AmountDisplay.kt
@@ -1,0 +1,38 @@
+package com.driverwallet.app.feature.input.ui.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun AmountDisplay(
+    displayAmount: String,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.End,
+        verticalAlignment = Alignment.Bottom,
+    ) {
+        Text(
+            text = "Rp",
+            style = MaterialTheme.typography.headlineSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+            text = displayAmount,
+            style = MaterialTheme.typography.displayLarge,
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 1,
+        )
+    }
+}

--- a/app/src/main/java/com/driverwallet/app/feature/input/ui/component/CategoryGrid.kt
+++ b/app/src/main/java/com/driverwallet/app/feature/input/ui/component/CategoryGrid.kt
@@ -1,0 +1,89 @@
+package com.driverwallet.app.feature.input.ui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.driverwallet.app.core.model.Category
+import com.driverwallet.app.core.ui.component.CategoryIcon
+
+@Composable
+fun CategoryGrid(
+    categories: List<Category>,
+    selectedCategory: Category?,
+    onCategorySelected: (Category) -> Unit,
+    modifier: Modifier = Modifier,
+    columns: Int = 4,
+) {
+    val rows = categories.chunked(columns)
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        rows.forEach { rowItems ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                rowItems.forEach { category ->
+                    CategoryItem(
+                        category = category,
+                        isSelected = category == selectedCategory,
+                        onClick = { onCategorySelected(category) },
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+                repeat(columns - rowItems.size) {
+                    Spacer(modifier = Modifier.weight(1f))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CategoryItem(
+    category: Category,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .clip(RoundedCornerShape(20.dp))
+            .clickable(onClick = onClick)
+            .background(
+                if (isSelected) MaterialTheme.colorScheme.primaryContainer
+                else Color.Transparent,
+            )
+            .padding(8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        CategoryIcon(
+            iconName = category.iconName,
+            contentDescription = category.label,
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text = category.label,
+            style = MaterialTheme.typography.labelSmall,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}

--- a/app/src/main/java/com/driverwallet/app/feature/input/ui/component/NoteInput.kt
+++ b/app/src/main/java/com/driverwallet/app/feature/input/ui/component/NoteInput.kt
@@ -1,0 +1,26 @@
+package com.driverwallet.app.feature.input.ui.component
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Edit
+import androidx.compose.material3.Icon
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun NoteInput(
+    note: String,
+    onNoteChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    OutlinedTextField(
+        value = note,
+        onValueChange = onNoteChange,
+        modifier = modifier.fillMaxWidth(),
+        placeholder = { Text("Tambah catatan...") },
+        leadingIcon = { Icon(Icons.Outlined.Edit, contentDescription = null) },
+        singleLine = true,
+    )
+}

--- a/app/src/main/java/com/driverwallet/app/feature/input/ui/component/NumberPad.kt
+++ b/app/src/main/java/com/driverwallet/app/feature/input/ui/component/NumberPad.kt
@@ -1,0 +1,59 @@
+package com.driverwallet.app.feature.input.ui.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+private val keys = listOf(
+    listOf("1", "2", "3"),
+    listOf("4", "5", "6"),
+    listOf("7", "8", "9"),
+    listOf("000", "0", "\u232B"),
+)
+
+@Composable
+fun NumberPad(
+    onDigit: (String) -> Unit,
+    onBackspace: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        keys.forEach { row ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                row.forEach { key ->
+                    FilledTonalButton(
+                        onClick = {
+                            if (key == "\u232B") onBackspace() else onDigit(key)
+                        },
+                        modifier = Modifier.weight(1f).height(56.dp),
+                        shape = RoundedCornerShape(50),
+                        colors = ButtonDefaults.filledTonalButtonColors(
+                            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                        ),
+                    ) {
+                        Text(
+                            text = key,
+                            style = MaterialTheme.typography.titleLarge,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/driverwallet/app/feature/input/ui/component/PresetButtons.kt
+++ b/app/src/main/java/com/driverwallet/app/feature/input/ui/component/PresetButtons.kt
@@ -1,0 +1,39 @@
+package com.driverwallet.app.feature.input.ui.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+private val presets = listOf(
+    5_000L to "+5rb",
+    10_000L to "+10rb",
+    20_000L to "+20rb",
+    50_000L to "+50rb",
+    100_000L to "+100rb",
+)
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun PresetButtons(
+    onPresetSelected: (Long) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    FlowRow(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        presets.forEach { (amount, label) ->
+            AssistChip(
+                onClick = { onPresetSelected(amount) },
+                label = { Text(label, style = MaterialTheme.typography.labelMedium) },
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/driverwallet/app/feature/input/ui/component/SaveButton.kt
+++ b/app/src/main/java/com/driverwallet/app/feature/input/ui/component/SaveButton.kt
@@ -1,0 +1,42 @@
+package com.driverwallet.app.feature.input.ui.component
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun SaveButton(
+    canSave: Boolean,
+    isSaving: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Button(
+        onClick = onClick,
+        modifier = modifier.fillMaxWidth().height(56.dp),
+        enabled = canSave,
+        shape = RoundedCornerShape(50),
+    ) {
+        if (isSaving) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(24.dp),
+                strokeWidth = 2.dp,
+                color = MaterialTheme.colorScheme.onPrimary,
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text("Menyimpan...")
+        } else {
+            Text("Simpan", style = MaterialTheme.typography.labelLarge)
+        }
+    }
+}

--- a/app/src/main/java/com/driverwallet/app/feature/input/ui/component/TypeToggle.kt
+++ b/app/src/main/java/com/driverwallet/app/feature/input/ui/component/TypeToggle.kt
@@ -1,0 +1,54 @@
+package com.driverwallet.app.feature.input.ui.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.driverwallet.app.core.model.TransactionType
+import com.driverwallet.app.core.ui.theme.ExpenseRed
+import com.driverwallet.app.core.ui.theme.IncomeGreen
+
+@Composable
+fun TypeToggle(
+    selectedType: TransactionType,
+    onTypeSelected: (TransactionType) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        TransactionType.entries.forEach { type ->
+            val isSelected = type == selectedType
+            val label = when (type) {
+                TransactionType.INCOME -> "MASUK"
+                TransactionType.EXPENSE -> "KELUAR"
+            }
+            Button(
+                onClick = { onTypeSelected(type) },
+                modifier = Modifier.weight(1f).height(48.dp),
+                shape = RoundedCornerShape(50),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = when {
+                        isSelected && type == TransactionType.INCOME -> IncomeGreen
+                        isSelected && type == TransactionType.EXPENSE -> ExpenseRed
+                        else -> MaterialTheme.colorScheme.surfaceVariant
+                    },
+                    contentColor = if (isSelected) Color.White
+                        else MaterialTheme.colorScheme.onSurfaceVariant,
+                ),
+            ) {
+                Text(label, style = MaterialTheme.typography.labelLarge)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 🎯 Tujuan
Bangun fitur input transaksi cepat — fitur paling sering dipakai. Target: < 3 detik, max 4 tap, 0 ketik.

**Closes #5**

---

## 🏗️ Architecture (MVI)

```
QuickInputScreen
  │ collectAsStateWithLifecycle()
  ↓
QuickInputViewModel (@HiltViewModel)
  │ StateFlow<QuickInputUiState>
  │ SharedFlow<GlobalUiEvent>
  ↓
SaveTransactionUseCase (@Inject)
  │ validates amount, note, category
  ↓
TransactionRepository.insert()
```

## 📦 Files (13)

### Domain (1)
- `SaveTransactionUseCase` — validates amount (>0, ≤999.999.999), note (max 100), category (non-null)

### State Management (3)
- `QuickInputUiState` — sealed: `Loading`, `Ready` (with computed `canSave`)
- `QuickInputUiAction` — sealed: SwitchType, SelectCategory, AppendDigit, Backspace, AddPreset, UpdateNote, Save
- `QuickInputViewModel` — processes all actions, manages amount string, emits GlobalUiEvent

### UI Components (7)
| Component | Description |
|---|---|
| `TypeToggle` | MASUK (green) / KELUAR (red) pill buttons |
| `AmountDisplay` | displayLarge amount with Rp prefix, right-aligned |
| `PresetButtons` | FlowRow chips: +5rb, +10rb, +20rb, +50rb, +100rb (ADDITIVE) |
| `NumberPad` | 3×4 grid: 1-9, 000, 0, ⌫. FilledTonalButton pill shape |
| `CategoryGrid` | Non-lazy grid (4 cols), highlight selected with primaryContainer |
| `NoteInput` | OutlinedTextField with edit icon, max 100 chars |
| `SaveButton` | Full-width pill, disabled when !canSave, loading spinner |

### Screen + Navigation (2)
- `QuickInputScreen` — Scaffold + SnackbarHost, scrollable Column
- `AppNavigation` — updated: Input tab → QuickInputScreen (others remain placeholder)

---

## ⚠️ Key Behaviors
- Preset buttons are **ADDITIVE** (10rb + preset 5rb = 15rb)
- `AppendDigit("000")` adds 3 digits at once
- `SwitchType` resets `selectedCategory` to null
- Amount capped at 999,999,999 (9 digits max)
- Save button disabled to prevent double-tap
- Form resets after successful save
- Snackbar: "✔️ Pemasukan Rp 50.000 tersimpan"

---

## ✅ Checklist
- [x] MVI pattern: UiState + UiAction + ViewModel
- [x] SaveTransactionUseCase validates all fields
- [x] Amount string builder handles digits + presets + backspace
- [x] TypeToggle with semantic colors (income=green, expense=red)
- [x] CategoryGrid non-lazy (safe inside scrollable Column)
- [x] NumberPad with 000 key and backspace
- [x] SaveButton disabled state + loading indicator
- [x] Snackbar feedback via GlobalUiEvent
- [x] Form reset after save
- [x] AppNavigation integrates QuickInputScreen