### PR TITLE
Phase 4: Feature — Dashboard / Beranda (F01) 🏠

### DIFF
--- a/app/src/main/java/com/driverwallet/app/core/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/driverwallet/app/core/ui/navigation/AppNavigation.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import com.driverwallet.app.feature.dashboard.ui.DashboardScreen
 import com.driverwallet.app.feature.input.ui.QuickInputScreen
 
 @Composable
@@ -34,7 +35,7 @@ fun AppNavigation(modifier: Modifier = Modifier) {
                 .padding(innerPadding),
         ) {
             when (selectedTab) {
-                0 -> PlaceholderScreen("Beranda")
+                0 -> DashboardScreen()
                 1 -> QuickInputScreen()
                 2 -> PlaceholderScreen("Hutang")
                 3 -> PlaceholderScreen("Laporan")

--- a/app/src/main/java/com/driverwallet/app/feature/dashboard/domain/usecase/CalculateDailyTargetUseCase.kt
+++ b/app/src/main/java/com/driverwallet/app/feature/dashboard/domain/usecase/CalculateDailyTargetUseCase.kt
@@ -1,0 +1,61 @@
+package com.driverwallet.app.feature.dashboard.domain.usecase
+
+import com.driverwallet.app.core.model.todayJakarta
+import com.driverwallet.app.feature.dashboard.domain.model.DailyTarget
+import com.driverwallet.app.feature.debt.domain.DebtRepository
+import com.driverwallet.app.feature.settings.domain.SettingsRepository
+import kotlinx.coroutines.flow.first
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
+import javax.inject.Inject
+
+class CalculateDailyTargetUseCase @Inject constructor(
+    private val debtRepository: DebtRepository,
+    private val settingsRepository: SettingsRepository,
+) {
+    suspend operator fun invoke(earnedToday: Long): DailyTarget {
+        val today = todayJakarta()
+
+        // Check rest day
+        val restDaysStr = settingsRepository.getSetting("rest_days") ?: "0"
+        val restDays = restDaysStr.split(",").mapNotNull { it.trim().toIntOrNull() }
+        val todayDow = today.dayOfWeek.value % 7 // 0=Sun, 1=Mon, ..., 6=Sat
+        val isRestDay = todayDow in restDays
+
+        if (isRestDay) {
+            return DailyTarget(targetAmount = 0L, earnedAmount = earnedToday, isRestDay = true)
+        }
+
+        // Daily debt target
+        val totalDebtRemaining = debtRepository.observeTotalRemaining().first()
+        val targetDateStr = settingsRepository.getSetting("debt_target_date")
+        val dailyDebtTarget = if (!targetDateStr.isNullOrEmpty()) {
+            runCatching {
+                val targetDate = LocalDate.parse(targetDateStr)
+                val daysRemaining = ChronoUnit.DAYS.between(today, targetDate).coerceAtLeast(1)
+                totalDebtRemaining / daysRemaining
+            }.getOrDefault(0L)
+        } else {
+            0L
+        }
+
+        // Monthly expenses prorated to daily
+        val totalMonthly = settingsRepository.getTotalMonthlyExpense()
+        val daysInMonth = today.lengthOfMonth().toLong().coerceAtLeast(1)
+        val dailyProrated = totalMonthly / daysInMonth
+
+        // Daily fixed expenses
+        val dailyFixed = settingsRepository.getTotalDailyExpense()
+
+        // Daily budget
+        val dailyBudget = settingsRepository.getTotalDailyBudget()
+
+        val targetAmount = dailyDebtTarget + dailyProrated + dailyFixed + dailyBudget
+
+        return DailyTarget(
+            targetAmount = targetAmount,
+            earnedAmount = earnedToday,
+            isRestDay = false,
+        )
+    }
+}

--- a/app/src/main/java/com/driverwallet/app/feature/dashboard/domain/usecase/GetDashboardSummaryUseCase.kt
+++ b/app/src/main/java/com/driverwallet/app/feature/dashboard/domain/usecase/GetDashboardSummaryUseCase.kt
@@ -1,0 +1,78 @@
+package com.driverwallet.app.feature.dashboard.domain.usecase
+
+import com.driverwallet.app.core.model.UrgencyLevel
+import com.driverwallet.app.core.model.todayJakarta
+import com.driverwallet.app.feature.dashboard.domain.model.BudgetInfo
+import com.driverwallet.app.feature.dashboard.domain.model.DashboardData
+import com.driverwallet.app.feature.dashboard.domain.model.DueAlert
+import com.driverwallet.app.feature.debt.domain.DebtRepository
+import com.driverwallet.app.feature.settings.domain.SettingsRepository
+import com.driverwallet.app.shared.data.repository.TransactionRepository
+import kotlinx.coroutines.flow.first
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
+import javax.inject.Inject
+
+class GetDashboardSummaryUseCase @Inject constructor(
+    private val transactionRepository: TransactionRepository,
+    private val debtRepository: DebtRepository,
+    private val settingsRepository: SettingsRepository,
+    private val calculateDailyTarget: CalculateDailyTargetUseCase,
+) {
+    suspend operator fun invoke(): DashboardData {
+        val today = todayJakarta()
+        val todayPrefix = today.toString()
+        val yesterdayPrefix = today.minusDays(1).toString()
+
+        // 1. Mark overdue schedules first
+        debtRepository.markOverdueSchedules(todayPrefix)
+
+        // 2. Today's summary
+        val todaySummary = transactionRepository.getTodaySummary(todayPrefix)
+
+        // 3. Yesterday's summary for % change
+        val yesterdaySummary = transactionRepository.getTodaySummary(yesterdayPrefix)
+        val yesterdayProfit = yesterdaySummary.profit
+
+        // 4. Budget info
+        val totalBudget = settingsRepository.getTotalDailyBudget()
+        val budgetCategories = listOf("fuel", "food", "cigarette", "phone")
+        val spentToday = transactionRepository.getBudgetSpentToday(todayPrefix, budgetCategories)
+        val budgetInfo = BudgetInfo(totalBudget = totalBudget, spentToday = spentToday)
+
+        // 5. Due alerts (next 7 days)
+        val maxDate = today.plusDays(7).toString()
+        val upcomingDue = debtRepository.getUpcomingDue(maxDate)
+        val dueAlerts = upcomingDue.map { tuple ->
+            val dueDate = LocalDate.parse(tuple.dueDate)
+            val daysUntil = ChronoUnit.DAYS.between(today, dueDate)
+            DueAlert(
+                debtId = tuple.debtId,
+                debtName = tuple.debtName,
+                platform = tuple.platform,
+                dueDate = tuple.dueDate,
+                amount = tuple.expectedAmount,
+                installmentNumber = tuple.installmentNumber,
+                urgency = UrgencyLevel.fromDaysUntilDue(daysUntil),
+            )
+        }
+
+        // 6. Recent transactions (today, max 5)
+        val recentTransactions = transactionRepository
+            .observeTodayTransactions()
+            .first()
+            .take(5)
+
+        // 7. Daily target
+        val dailyTarget = calculateDailyTarget(earnedToday = todaySummary.profit)
+
+        return DashboardData(
+            todaySummary = todaySummary,
+            dailyTarget = dailyTarget,
+            budgetInfo = budgetInfo,
+            dueAlerts = dueAlerts,
+            recentTransactions = recentTransactions,
+            yesterdayProfit = yesterdayProfit,
+        )
+    }
+}

--- a/app/src/main/java/com/driverwallet/app/feature/dashboard/ui/DashboardScreen.kt
+++ b/app/src/main/java/com/driverwallet/app/feature/dashboard/ui/DashboardScreen.kt
@@ -1,0 +1,114 @@
+package com.driverwallet.app.feature.dashboard.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Refresh
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.driverwallet.app.core.ui.component.LoadingIndicator
+import com.driverwallet.app.feature.dashboard.ui.component.BudgetRemainingCard
+import com.driverwallet.app.feature.dashboard.ui.component.DailyTargetSection
+import com.driverwallet.app.feature.dashboard.ui.component.DueAlertCard
+import com.driverwallet.app.feature.dashboard.ui.component.IncomeExpenseRow
+import com.driverwallet.app.feature.dashboard.ui.component.ProfitHeroCard
+import com.driverwallet.app.feature.dashboard.ui.component.TodayTransactionList
+
+@Composable
+fun DashboardScreen(
+    viewModel: DashboardViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    when (val state = uiState) {
+        is DashboardUiState.Loading -> LoadingIndicator()
+        is DashboardUiState.Error -> {
+            ErrorContent(
+                message = state.message,
+                onRetry = { viewModel.onAction(DashboardUiAction.Refresh) },
+            )
+        }
+        is DashboardUiState.Success -> {
+            DashboardContent(state = state)
+        }
+    }
+}
+
+@Composable
+private fun DashboardContent(
+    state: DashboardUiState.Success,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        item {
+            ProfitHeroCard(
+                profit = state.todaySummary.profit,
+                percentChange = state.percentChange,
+            )
+        }
+        item {
+            IncomeExpenseRow(
+                income = state.todaySummary.income,
+                expense = state.todaySummary.expense,
+            )
+        }
+        item {
+            DailyTargetSection(dailyTarget = state.dailyTarget)
+        }
+        item {
+            BudgetRemainingCard(budgetInfo = state.budgetInfo)
+        }
+        if (state.dueAlerts.isNotEmpty()) {
+            item {
+                DueAlertCard(alerts = state.dueAlerts)
+            }
+        }
+        item {
+            TodayTransactionList(transactions = state.recentTransactions)
+        }
+    }
+}
+
+@Composable
+private fun ErrorContent(
+    message: String,
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.error,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            TextButton(onClick = onRetry) {
+                Icon(Icons.Outlined.Refresh, contentDescription = null)
+                Text(" Coba Lagi")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/driverwallet/app/feature/dashboard/ui/DashboardUiState.kt
+++ b/app/src/main/java/com/driverwallet/app/feature/dashboard/ui/DashboardUiState.kt
@@ -1,0 +1,26 @@
+package com.driverwallet.app.feature.dashboard.ui
+
+import com.driverwallet.app.feature.dashboard.domain.model.BudgetInfo
+import com.driverwallet.app.feature.dashboard.domain.model.DailyTarget
+import com.driverwallet.app.feature.dashboard.domain.model.DueAlert
+import com.driverwallet.app.feature.dashboard.domain.model.TodaySummary
+import com.driverwallet.app.shared.domain.model.Transaction
+
+sealed interface DashboardUiState {
+    data object Loading : DashboardUiState
+
+    data class Success(
+        val todaySummary: TodaySummary,
+        val percentChange: Float?,
+        val dailyTarget: DailyTarget,
+        val budgetInfo: BudgetInfo,
+        val dueAlerts: List<DueAlert>,
+        val recentTransactions: List<Transaction>,
+    ) : DashboardUiState
+
+    data class Error(val message: String) : DashboardUiState
+}
+
+sealed interface DashboardUiAction {
+    data object Refresh : DashboardUiAction
+}

--- a/app/src/main/java/com/driverwallet/app/feature/dashboard/ui/DashboardViewModel.kt
+++ b/app/src/main/java/com/driverwallet/app/feature/dashboard/ui/DashboardViewModel.kt
@@ -1,0 +1,59 @@
+package com.driverwallet.app.feature.dashboard.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.driverwallet.app.feature.dashboard.domain.usecase.GetDashboardSummaryUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class DashboardViewModel @Inject constructor(
+    private val getDashboardSummary: GetDashboardSummaryUseCase,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<DashboardUiState>(DashboardUiState.Loading)
+    val uiState: StateFlow<DashboardUiState> = _uiState.asStateFlow()
+
+    init {
+        loadDashboard()
+    }
+
+    fun onAction(action: DashboardUiAction) {
+        when (action) {
+            is DashboardUiAction.Refresh -> loadDashboard()
+        }
+    }
+
+    private fun loadDashboard() {
+        viewModelScope.launch {
+            _uiState.value = DashboardUiState.Loading
+            runCatching { getDashboardSummary() }
+                .onSuccess { data ->
+                    val percentChange = data.yesterdayProfit?.let { yesterday ->
+                        if (yesterday != 0L) {
+                            ((data.todaySummary.profit - yesterday).toFloat() / yesterday * 100f)
+                        } else {
+                            null
+                        }
+                    }
+                    _uiState.value = DashboardUiState.Success(
+                        todaySummary = data.todaySummary,
+                        percentChange = percentChange,
+                        dailyTarget = data.dailyTarget,
+                        budgetInfo = data.budgetInfo,
+                        dueAlerts = data.dueAlerts,
+                        recentTransactions = data.recentTransactions,
+                    )
+                }
+                .onFailure { error ->
+                    _uiState.value = DashboardUiState.Error(
+                        error.message ?: "Gagal memuat data",
+                    )
+                }
+        }
+    }
+}

--- a/app/src/main/java/com/driverwallet/app/feature/dashboard/ui/component/BudgetRemainingCard.kt
+++ b/app/src/main/java/com/driverwallet/app/feature/dashboard/ui/component/BudgetRemainingCard.kt
@@ -1,0 +1,46 @@
+package com.driverwallet.app.feature.dashboard.ui.component
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.driverwallet.app.core.ui.component.AmountText
+import com.driverwallet.app.core.ui.component.AppProgressBar
+import com.driverwallet.app.core.util.CurrencyFormatter
+import com.driverwallet.app.feature.dashboard.domain.model.BudgetInfo
+
+@Composable
+fun BudgetRemainingCard(
+    budgetInfo: BudgetInfo,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text("Sisa Budget Hari Ini", style = MaterialTheme.typography.titleSmall)
+            Spacer(modifier = Modifier.height(8.dp))
+            AmountText(
+                amount = budgetInfo.remaining,
+                style = MaterialTheme.typography.headlineSmall,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            AppProgressBar(progress = budgetInfo.percentage)
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = "Terpakai Rp ${CurrencyFormatter.format(budgetInfo.spentToday)} dari Rp ${CurrencyFormatter.format(budgetInfo.totalBudget)}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/driverwallet/app/feature/dashboard/ui/component/DailyTargetSection.kt
+++ b/app/src/main/java/com/driverwallet/app/feature/dashboard/ui/component/DailyTargetSection.kt
@@ -1,0 +1,74 @@
+package com.driverwallet.app.feature.dashboard.ui.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.driverwallet.app.core.ui.component.AppProgressBar
+import com.driverwallet.app.core.ui.theme.ExpenseRed
+import com.driverwallet.app.core.ui.theme.IncomeGreen
+import com.driverwallet.app.core.util.CurrencyFormatter
+import com.driverwallet.app.feature.dashboard.domain.model.DailyTarget
+
+@Composable
+fun DailyTargetSection(
+    dailyTarget: DailyTarget,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text("Target Harian", style = MaterialTheme.typography.titleSmall)
+                Surface(
+                    shape = RoundedCornerShape(50),
+                    color = if (dailyTarget.isOnTrack) IncomeGreen else ExpenseRed,
+                ) {
+                    Text(
+                        text = if (dailyTarget.isOnTrack) "ON TRACK" else "OFF TRACK",
+                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp),
+                        color = Color.White,
+                        style = MaterialTheme.typography.labelSmall,
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.height(12.dp))
+            AppProgressBar(progress = dailyTarget.percentage)
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(
+                    text = "Rp ${CurrencyFormatter.format(dailyTarget.earnedAmount)}",
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                Text(
+                    text = "Rp ${CurrencyFormatter.format(dailyTarget.targetAmount)}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/driverwallet/app/feature/dashboard/ui/component/DueAlertCard.kt
+++ b/app/src/main/java/com/driverwallet/app/feature/dashboard/ui/component/DueAlertCard.kt
@@ -1,0 +1,90 @@
+package com.driverwallet.app.feature.dashboard.ui.component
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Notifications
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.driverwallet.app.core.ui.component.AmountText
+import com.driverwallet.app.feature.dashboard.domain.model.DueAlert
+
+@Composable
+fun DueAlertCard(
+    alerts: List<DueAlert>,
+    modifier: Modifier = Modifier,
+) {
+    if (alerts.isEmpty()) return
+
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.errorContainer,
+        ),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.error),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    Icons.Outlined.Notifications,
+                    contentDescription = "Peringatan jatuh tempo",
+                    tint = MaterialTheme.colorScheme.error,
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    "Jatuh Tempo",
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onErrorContainer,
+                )
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            alerts.forEachIndexed { index, alert ->
+                DueAlertItem(alert = alert)
+                if (index < alerts.lastIndex) {
+                    HorizontalDivider(
+                        modifier = Modifier.padding(vertical = 4.dp),
+                        color = MaterialTheme.colorScheme.error.copy(alpha = 0.3f),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DueAlertItem(alert: DueAlert) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(alert.debtName, style = MaterialTheme.typography.bodyMedium)
+            Text(
+                text = "Cicilan ke-${alert.installmentNumber} \u2022 ${alert.dueDate}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onErrorContainer.copy(alpha = 0.7f),
+            )
+        }
+        AmountText(
+            amount = alert.amount,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.error,
+        )
+    }
+}

--- a/app/src/main/java/com/driverwallet/app/feature/dashboard/ui/component/IncomeExpenseRow.kt
+++ b/app/src/main/java/com/driverwallet/app/feature/dashboard/ui/component/IncomeExpenseRow.kt
@@ -1,0 +1,74 @@
+package com.driverwallet.app.feature.dashboard.ui.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ArrowDownward
+import androidx.compose.material.icons.outlined.ArrowUpward
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.driverwallet.app.core.ui.component.AmountText
+import com.driverwallet.app.core.ui.theme.ExpenseRed
+import com.driverwallet.app.core.ui.theme.IncomeGreen
+
+@Composable
+fun IncomeExpenseRow(
+    income: Long,
+    expense: Long,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        SummaryCard(
+            label = "Masuk",
+            amount = income,
+            icon = { Icon(Icons.Outlined.ArrowDownward, contentDescription = "Pemasukan", tint = IncomeGreen, modifier = Modifier.size(20.dp)) },
+            modifier = Modifier.weight(1f),
+        )
+        SummaryCard(
+            label = "Keluar",
+            amount = expense,
+            icon = { Icon(Icons.Outlined.ArrowUpward, contentDescription = "Pengeluaran", tint = ExpenseRed, modifier = Modifier.size(20.dp)) },
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
+
+@Composable
+private fun SummaryCard(
+    label: String,
+    amount: Long,
+    icon: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier,
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                icon()
+                Spacer(modifier = Modifier.width(4.dp))
+                Text(label, style = MaterialTheme.typography.labelMedium)
+            }
+            Spacer(modifier = Modifier.height(4.dp))
+            AmountText(amount = amount, style = MaterialTheme.typography.titleMedium)
+        }
+    }
+}

--- a/app/src/main/java/com/driverwallet/app/feature/dashboard/ui/component/ProfitHeroCard.kt
+++ b/app/src/main/java/com/driverwallet/app/feature/dashboard/ui/component/ProfitHeroCard.kt
@@ -1,0 +1,59 @@
+package com.driverwallet.app.feature.dashboard.ui.component
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.driverwallet.app.core.ui.component.AmountText
+import com.driverwallet.app.core.ui.component.HeroCard
+import com.driverwallet.app.core.ui.theme.ExpenseRed
+import com.driverwallet.app.core.ui.theme.HeroAmountStyle
+import com.driverwallet.app.core.ui.theme.IncomeGreen
+
+@Composable
+fun ProfitHeroCard(
+    profit: Long,
+    percentChange: Float?,
+    modifier: Modifier = Modifier,
+) {
+    HeroCard(modifier = modifier) {
+        Text(
+            text = "Keuntungan Hari Ini",
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onPrimaryContainer,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Row(verticalAlignment = Alignment.Bottom) {
+            AmountText(
+                amount = profit,
+                style = HeroAmountStyle,
+                color = MaterialTheme.colorScheme.onPrimaryContainer,
+            )
+            if (percentChange != null) {
+                Spacer(modifier = Modifier.width(8.dp))
+                val isPositive = percentChange >= 0
+                Surface(
+                    shape = RoundedCornerShape(50),
+                    color = if (isPositive) IncomeGreen else ExpenseRed,
+                ) {
+                    Text(
+                        text = "${if (isPositive) "+" else ""}${percentChange.toInt()}%",
+                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+                        color = Color.White,
+                        style = MaterialTheme.typography.labelSmall,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/driverwallet/app/feature/dashboard/ui/component/TodayTransactionList.kt
+++ b/app/src/main/java/com/driverwallet/app/feature/dashboard/ui/component/TodayTransactionList.kt
@@ -1,0 +1,86 @@
+package com.driverwallet.app.feature.dashboard.ui.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.driverwallet.app.core.model.TransactionType
+import com.driverwallet.app.core.ui.component.AmountText
+import com.driverwallet.app.core.ui.component.CategoryIcon
+import com.driverwallet.app.core.ui.theme.ExpenseRed
+import com.driverwallet.app.core.ui.theme.IncomeGreen
+import com.driverwallet.app.shared.domain.model.Transaction
+
+@Composable
+fun TodayTransactionList(
+    transactions: List<Transaction>,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
+        Text("Transaksi Hari Ini", style = MaterialTheme.typography.titleSmall)
+        Spacer(modifier = Modifier.height(8.dp))
+        if (transactions.isEmpty()) {
+            Text(
+                text = "Belum ada transaksi hari ini",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        } else {
+            transactions.forEachIndexed { index, transaction ->
+                TransactionItem(transaction = transaction)
+                if (index < transactions.lastIndex) {
+                    HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TransactionItem(transaction: Transaction) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        CategoryIcon(
+            iconName = transaction.category?.iconName ?: "add",
+            contentDescription = transaction.category?.label,
+        )
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = transaction.category?.label ?: "Lainnya",
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            if (transaction.note.isNotEmpty()) {
+                Text(
+                    text = transaction.note,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+        AmountText(
+            amount = transaction.amount,
+            style = MaterialTheme.typography.bodyMedium,
+            color = if (transaction.type == TransactionType.INCOME) IncomeGreen else ExpenseRed,
+            prefix = if (transaction.type == TransactionType.INCOME) "+Rp " else "-Rp ",
+        )
+    }
+}


### PR DESCRIPTION
## 🎯 Tujuan
Bangun halaman utama yang menampilkan ringkasan keuangan harian: profit, target, budget, due alerts, dan transaksi terkini.

**Closes #6**

---

## 🏗️ Architecture

```
DashboardScreen
  │ collectAsStateWithLifecycle()
  ↓
DashboardViewModel (@HiltViewModel)
  │ StateFlow<DashboardUiState>
  ↓
GetDashboardSummaryUseCase (@Inject)
  ├─ transactionRepository.getTodaySummary()
  ├─ CalculateDailyTargetUseCase (formula)
  ├─ settingsRepository.getTotalDailyBudget()
  ├─ debtRepository.getUpcomingDue()
  ├─ debtRepository.markOverdueSchedules()
  └─ transactionRepository.observeTodayTransactions().first()
```

## 📦 Files (12)

### Domain (2)
- `GetDashboardSummaryUseCase` — orchestrates 7 data queries, marks overdue schedules first, returns `DashboardData`
- `CalculateDailyTargetUseCase` — formula: `dailyDebt + prorated + fixed + budget`. Rest day check via `DayOfWeek`. `coerceAtLeast(1)` for division safety.

### State Management (2)
- `DashboardUiState` — sealed: Loading, Success (6 fields + percentChange), Error(message)
- `DashboardViewModel` — loads on init, refresh via `DashboardUiAction.Refresh`

### UI Components (6)
| Component | Description |
|---|---|
| `ProfitHeroCard` | primaryContainer, 42sp profit, % change badge (green/red Surface pill) |
| `IncomeExpenseRow` | 2-col: income card (↓ green) + expense card (↑ red) |
| `DailyTargetSection` | progress bar + ON/OFF TRACK badge + earned/target amounts |
| `BudgetRemainingCard` | remaining amount + progress bar + spent/total text |
| `DueAlertCard` | errorContainer + error border, notification icon, per-alert rows |
| `TodayTransactionList` | max 5 recent, category icon, note, signed colored amount |

### Screen + Navigation (2)
- `DashboardScreen` — LazyColumn, Loading/Error/Success states, error retry
- `AppNavigation` — Beranda tab → DashboardScreen, Input tab → QuickInputScreen

---

## 🔑 Key Design Decisions

### Daily Target Formula
```
targetAmount = dailyDebtTarget + dailyProrated + dailyFixed + dailyBudget

dailyDebtTarget = totalDebtRemaining / daysUntilTargetDate
dailyProrated   = totalMonthlyExpenses / daysInMonth
dailyFixed      = totalDailyExpenses
dailyBudget     = totalDailyBudgets

If rest day → targetAmount = 0, isOnTrack = true
```

### markOverdueSchedules First
Before building the dashboard, we mark any past-due schedules as overdue. This ensures DueAlertCard shows correct urgency levels.

### Recent Transactions via Flow.first()
Using `observeTodayTransactions().first().take(5)` instead of `getByDateRange()` because the LIKE-based query correctly handles ISO datetime string matching.

---

## ✅ Checklist
- [x] GetDashboardSummaryUseCase orchestrates all data
- [x] CalculateDailyTargetUseCase with rest day + formula
- [x] MVI: UiState sealed + UiAction + ViewModel
- [x] ProfitHeroCard with % change badge
- [x] IncomeExpenseRow 2-col with semantic colors
- [x] DailyTargetSection with ON/OFF TRACK
- [x] BudgetRemainingCard with progress bar
- [x] DueAlertCard with error theme + per-alert items
- [x] TodayTransactionList with category icons
- [x] DashboardScreen with LazyColumn + Error retry
- [x] AppNavigation routes Beranda to DashboardScreen