### PR TITLE
feat: Phase 7 — Settings / Pengaturan (F07) ⚙️

### DIFF
--- a/app/src/main/java/com/driverwallet/app/feature/settings/domain/SettingsKeys.kt
+++ b/app/src/main/java/com/driverwallet/app/feature/settings/domain/SettingsKeys.kt
@@ -1,0 +1,6 @@
+package com.driverwallet.app.feature.settings.domain
+
+object SettingsKeys {
+    const val DARK_MODE = "dark_mode"
+    const val TARGET_DATE = "target_date"
+}

--- a/app/src/main/java/com/driverwallet/app/feature/settings/domain/usecase/SaveDailyBudgetsUseCase.kt
+++ b/app/src/main/java/com/driverwallet/app/feature/settings/domain/usecase/SaveDailyBudgetsUseCase.kt
@@ -1,0 +1,26 @@
+package com.driverwallet.app.feature.settings.domain.usecase
+
+import com.driverwallet.app.feature.settings.data.entity.DailyBudgetEntity
+import com.driverwallet.app.feature.settings.domain.SettingsRepository
+import javax.inject.Inject
+
+class SaveDailyBudgetsUseCase @Inject constructor(
+    private val settingsRepository: SettingsRepository,
+) {
+    suspend operator fun invoke(budgets: Map<String, Long>): Result<Unit> {
+        return runCatching {
+            val existing = settingsRepository.getDailyBudgets()
+            val existingMap = existing.associateBy { it.category }
+
+            val entities = budgets.map { (category, amount) ->
+                require(amount >= 0) { "Budget untuk $category tidak boleh negatif" }
+                DailyBudgetEntity(
+                    id = existingMap[category]?.id ?: 0,
+                    category = category,
+                    amount = amount,
+                )
+            }
+            settingsRepository.saveBudgets(entities)
+        }
+    }
+}

--- a/app/src/main/java/com/driverwallet/app/feature/settings/domain/usecase/SaveDailyExpenseUseCase.kt
+++ b/app/src/main/java/com/driverwallet/app/feature/settings/domain/usecase/SaveDailyExpenseUseCase.kt
@@ -1,0 +1,24 @@
+package com.driverwallet.app.feature.settings.domain.usecase
+
+import com.driverwallet.app.feature.settings.data.entity.DailyExpenseEntity
+import com.driverwallet.app.feature.settings.domain.SettingsRepository
+import javax.inject.Inject
+
+class SaveDailyExpenseUseCase @Inject constructor(
+    private val settingsRepository: SettingsRepository,
+) {
+    suspend operator fun invoke(
+        id: Long = 0,
+        name: String,
+        amount: Long,
+        icon: String = "payments",
+    ): Result<Unit> {
+        return runCatching {
+            require(name.isNotBlank()) { "Nama tidak boleh kosong" }
+            require(amount > 0) { "Jumlah harus lebih dari 0" }
+            settingsRepository.saveDailyExpense(
+                DailyExpenseEntity(id = id, name = name, icon = icon, amount = amount),
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/driverwallet/app/feature/settings/domain/usecase/SaveMonthlyExpenseUseCase.kt
+++ b/app/src/main/java/com/driverwallet/app/feature/settings/domain/usecase/SaveMonthlyExpenseUseCase.kt
@@ -1,0 +1,24 @@
+package com.driverwallet.app.feature.settings.domain.usecase
+
+import com.driverwallet.app.feature.settings.data.entity.MonthlyExpenseEntity
+import com.driverwallet.app.feature.settings.domain.SettingsRepository
+import javax.inject.Inject
+
+class SaveMonthlyExpenseUseCase @Inject constructor(
+    private val settingsRepository: SettingsRepository,
+) {
+    suspend operator fun invoke(
+        id: Long = 0,
+        name: String,
+        amount: Long,
+        icon: String = "payments",
+    ): Result<Unit> {
+        return runCatching {
+            require(name.isNotBlank()) { "Nama tidak boleh kosong" }
+            require(amount > 0) { "Jumlah harus lebih dari 0" }
+            settingsRepository.saveMonthlyExpense(
+                MonthlyExpenseEntity(id = id, name = name, icon = icon, amount = amount),
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/driverwallet/app/feature/settings/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/driverwallet/app/feature/settings/ui/SettingsScreen.kt
@@ -1,0 +1,191 @@
+package com.driverwallet.app.feature.settings.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.driverwallet.app.core.ui.navigation.GlobalUiEvent
+import com.driverwallet.app.feature.settings.ui.component.BudgetSection
+import com.driverwallet.app.feature.settings.ui.component.DarkModeToggle
+import com.driverwallet.app.feature.settings.ui.component.ExpenseFormDialog
+import com.driverwallet.app.feature.settings.ui.component.FixedExpenseDisplay
+import com.driverwallet.app.feature.settings.ui.component.FixedExpenseSection
+import com.driverwallet.app.feature.settings.ui.component.TargetDateRow
+
+@Composable
+fun SettingsScreen(
+    viewModel: SettingsViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(Unit) {
+        viewModel.uiEvent.collect { event ->
+            when (event) {
+                is GlobalUiEvent.ShowSnackbar -> snackbarHostState.showSnackbar(event.message)
+                else -> Unit
+            }
+        }
+    }
+
+    Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+    ) { innerPadding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+            contentPadding = PaddingValues(vertical = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            // Header
+            item {
+                Text(
+                    text = "Pengaturan",
+                    style = MaterialTheme.typography.headlineMedium,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+            }
+
+            // Dark Mode
+            item {
+                DarkModeToggle(
+                    isDarkMode = uiState.isDarkMode,
+                    onToggle = { viewModel.onAction(SettingsUiAction.ToggleDarkMode(it)) },
+                )
+                HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
+            }
+
+            // Budget Section
+            item {
+                Spacer(modifier = Modifier.height(8.dp))
+                BudgetSection(
+                    budgetBbm = uiState.budgetBbm,
+                    budgetMakan = uiState.budgetMakan,
+                    budgetRokok = uiState.budgetRokok,
+                    budgetPulsa = uiState.budgetPulsa,
+                    onBudgetChange = { category, value ->
+                        viewModel.onAction(SettingsUiAction.UpdateBudget(category, value))
+                    },
+                )
+            }
+
+            // Target Date
+            item {
+                Spacer(modifier = Modifier.height(8.dp))
+                TargetDateRow(
+                    targetDate = uiState.targetDate,
+                    onDateSelected = { viewModel.onAction(SettingsUiAction.UpdateTargetDate(it)) },
+                )
+            }
+
+            // Monthly Expenses
+            item {
+                Spacer(modifier = Modifier.height(8.dp))
+                HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                Spacer(modifier = Modifier.height(8.dp))
+                FixedExpenseSection(
+                    title = "Pengeluaran Tetap Bulanan",
+                    expenses = uiState.monthlyExpenses.map {
+                        FixedExpenseDisplay(it.id, it.name, it.icon, it.amount)
+                    },
+                    onAdd = { viewModel.onAction(SettingsUiAction.ShowAddExpense(isMonthly = true)) },
+                    onEdit = { expense ->
+                        viewModel.onAction(
+                            SettingsUiAction.ShowEditExpense(
+                                id = expense.id,
+                                name = expense.name,
+                                amount = expense.amount,
+                                icon = expense.icon,
+                                isMonthly = true,
+                            ),
+                        )
+                    },
+                    onDelete = { id ->
+                        viewModel.onAction(SettingsUiAction.DeleteExpense(id, isMonthly = true))
+                    },
+                )
+            }
+
+            // Daily Expenses
+            item {
+                Spacer(modifier = Modifier.height(8.dp))
+                FixedExpenseSection(
+                    title = "Pengeluaran Tetap Harian",
+                    expenses = uiState.dailyExpenses.map {
+                        FixedExpenseDisplay(it.id, it.name, it.icon, it.amount)
+                    },
+                    onAdd = { viewModel.onAction(SettingsUiAction.ShowAddExpense(isMonthly = false)) },
+                    onEdit = { expense ->
+                        viewModel.onAction(
+                            SettingsUiAction.ShowEditExpense(
+                                id = expense.id,
+                                name = expense.name,
+                                amount = expense.amount,
+                                icon = expense.icon,
+                                isMonthly = false,
+                            ),
+                        )
+                    },
+                    onDelete = { id ->
+                        viewModel.onAction(SettingsUiAction.DeleteExpense(id, isMonthly = false))
+                    },
+                )
+            }
+
+            // Save Button
+            item {
+                Spacer(modifier = Modifier.height(16.dp))
+                Button(
+                    onClick = { viewModel.onAction(SettingsUiAction.SaveAll) },
+                    enabled = !uiState.isSaving,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp),
+                ) {
+                    if (uiState.isSaving) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.height(20.dp),
+                            strokeWidth = 2.dp,
+                        )
+                    } else {
+                        Text("Simpan Perubahan")
+                    }
+                }
+                Spacer(modifier = Modifier.height(32.dp))
+            }
+        }
+    }
+
+    // Expense Form Dialog
+    if (uiState.showExpenseDialog && uiState.editingExpense != null) {
+        ExpenseFormDialog(
+            expense = uiState.editingExpense!!,
+            onDismiss = { viewModel.onAction(SettingsUiAction.DismissExpenseDialog) },
+            onSave = { viewModel.onAction(SettingsUiAction.SaveExpense(it)) },
+        )
+    }
+}

--- a/app/src/main/java/com/driverwallet/app/feature/settings/ui/SettingsUiState.kt
+++ b/app/src/main/java/com/driverwallet/app/feature/settings/ui/SettingsUiState.kt
@@ -1,0 +1,44 @@
+package com.driverwallet.app.feature.settings.ui
+
+import com.driverwallet.app.feature.settings.data.entity.DailyExpenseEntity
+import com.driverwallet.app.feature.settings.data.entity.MonthlyExpenseEntity
+
+data class SettingsUiState(
+    val isDarkMode: Boolean = false,
+    val budgetBbm: String = "",
+    val budgetMakan: String = "",
+    val budgetRokok: String = "",
+    val budgetPulsa: String = "",
+    val targetDate: String = "",
+    val monthlyExpenses: List<MonthlyExpenseEntity> = emptyList(),
+    val dailyExpenses: List<DailyExpenseEntity> = emptyList(),
+    val isSaving: Boolean = false,
+    val showExpenseDialog: Boolean = false,
+    val editingExpense: EditingExpense? = null,
+)
+
+data class EditingExpense(
+    val id: Long = 0,
+    val name: String = "",
+    val amount: String = "",
+    val icon: String = "payments",
+    val isMonthly: Boolean = true,
+)
+
+sealed interface SettingsUiAction {
+    data class ToggleDarkMode(val enabled: Boolean) : SettingsUiAction
+    data class UpdateBudget(val category: String, val value: String) : SettingsUiAction
+    data class UpdateTargetDate(val date: String) : SettingsUiAction
+    data object SaveAll : SettingsUiAction
+    data class ShowAddExpense(val isMonthly: Boolean) : SettingsUiAction
+    data class ShowEditExpense(
+        val id: Long,
+        val name: String,
+        val amount: Long,
+        val icon: String,
+        val isMonthly: Boolean,
+    ) : SettingsUiAction
+    data object DismissExpenseDialog : SettingsUiAction
+    data class SaveExpense(val expense: EditingExpense) : SettingsUiAction
+    data class DeleteExpense(val id: Long, val isMonthly: Boolean) : SettingsUiAction
+}

--- a/app/src/main/java/com/driverwallet/app/feature/settings/ui/SettingsViewModel.kt
+++ b/app/src/main/java/com/driverwallet/app/feature/settings/ui/SettingsViewModel.kt
@@ -1,0 +1,209 @@
+package com.driverwallet.app.feature.settings.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.driverwallet.app.core.ui.navigation.GlobalUiEvent
+import com.driverwallet.app.feature.settings.domain.SettingsKeys
+import com.driverwallet.app.feature.settings.domain.SettingsRepository
+import com.driverwallet.app.feature.settings.domain.usecase.SaveDailyBudgetsUseCase
+import com.driverwallet.app.feature.settings.domain.usecase.SaveDailyExpenseUseCase
+import com.driverwallet.app.feature.settings.domain.usecase.SaveMonthlyExpenseUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class SettingsViewModel @Inject constructor(
+    private val settingsRepository: SettingsRepository,
+    private val saveDailyBudgets: SaveDailyBudgetsUseCase,
+    private val saveMonthlyExpense: SaveMonthlyExpenseUseCase,
+    private val saveDailyExpense: SaveDailyExpenseUseCase,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(SettingsUiState())
+    val uiState: StateFlow<SettingsUiState> = _uiState.asStateFlow()
+
+    private val _uiEvent = MutableSharedFlow<GlobalUiEvent>()
+    val uiEvent = _uiEvent.asSharedFlow()
+
+    init {
+        observeDarkMode()
+        observeTargetDate()
+        observeBudgets()
+        observeMonthlyExpenses()
+        observeDailyExpenses()
+    }
+
+    private fun observeDarkMode() {
+        viewModelScope.launch {
+            settingsRepository.observeSetting(SettingsKeys.DARK_MODE).collect { value ->
+                _uiState.update { it.copy(isDarkMode = value == "true") }
+            }
+        }
+    }
+
+    private fun observeTargetDate() {
+        viewModelScope.launch {
+            settingsRepository.observeSetting(SettingsKeys.TARGET_DATE).collect { value ->
+                _uiState.update { it.copy(targetDate = value ?: "") }
+            }
+        }
+    }
+
+    private fun observeBudgets() {
+        viewModelScope.launch {
+            settingsRepository.observeDailyBudgets().collect { budgets ->
+                val map = budgets.associate { it.category to it.amount.toString() }
+                _uiState.update {
+                    it.copy(
+                        budgetBbm = map["fuel"] ?: "0",
+                        budgetMakan = map["food"] ?: "0",
+                        budgetRokok = map["cigarette"] ?: "0",
+                        budgetPulsa = map["phone"] ?: "0",
+                    )
+                }
+            }
+        }
+    }
+
+    private fun observeMonthlyExpenses() {
+        viewModelScope.launch {
+            settingsRepository.observeMonthlyExpenses().collect { expenses ->
+                _uiState.update { it.copy(monthlyExpenses = expenses) }
+            }
+        }
+    }
+
+    private fun observeDailyExpenses() {
+        viewModelScope.launch {
+            settingsRepository.observeDailyExpenses().collect { expenses ->
+                _uiState.update { it.copy(dailyExpenses = expenses) }
+            }
+        }
+    }
+
+    fun onAction(action: SettingsUiAction) {
+        when (action) {
+            is SettingsUiAction.ToggleDarkMode -> toggleDarkMode(action.enabled)
+            is SettingsUiAction.UpdateBudget -> updateBudgetField(action.category, action.value)
+            is SettingsUiAction.UpdateTargetDate -> _uiState.update { it.copy(targetDate = action.date) }
+            is SettingsUiAction.SaveAll -> saveAll()
+            is SettingsUiAction.ShowAddExpense -> showAddDialog(action.isMonthly)
+            is SettingsUiAction.ShowEditExpense -> showEditDialog(action)
+            is SettingsUiAction.DismissExpenseDialog -> dismissDialog()
+            is SettingsUiAction.SaveExpense -> saveExpense(action.expense)
+            is SettingsUiAction.DeleteExpense -> deleteExpense(action.id, action.isMonthly)
+        }
+    }
+
+    private fun toggleDarkMode(enabled: Boolean) {
+        viewModelScope.launch {
+            settingsRepository.saveSetting(SettingsKeys.DARK_MODE, enabled.toString())
+        }
+    }
+
+    private fun updateBudgetField(category: String, value: String) {
+        _uiState.update {
+            when (category) {
+                "fuel" -> it.copy(budgetBbm = value)
+                "food" -> it.copy(budgetMakan = value)
+                "cigarette" -> it.copy(budgetRokok = value)
+                "phone" -> it.copy(budgetPulsa = value)
+                else -> it
+            }
+        }
+    }
+
+    private fun saveAll() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSaving = true) }
+            val state = _uiState.value
+
+            val budgets = mapOf(
+                "fuel" to (state.budgetBbm.toLongOrNull() ?: 0L),
+                "food" to (state.budgetMakan.toLongOrNull() ?: 0L),
+                "cigarette" to (state.budgetRokok.toLongOrNull() ?: 0L),
+                "phone" to (state.budgetPulsa.toLongOrNull() ?: 0L),
+            )
+            saveDailyBudgets(budgets)
+
+            if (state.targetDate.isNotBlank()) {
+                settingsRepository.saveSetting(SettingsKeys.TARGET_DATE, state.targetDate)
+            }
+
+            _uiState.update { it.copy(isSaving = false) }
+            _uiEvent.emit(GlobalUiEvent.ShowSnackbar("Pengaturan berhasil disimpan"))
+        }
+    }
+
+    private fun showAddDialog(isMonthly: Boolean) {
+        _uiState.update {
+            it.copy(
+                showExpenseDialog = true,
+                editingExpense = EditingExpense(isMonthly = isMonthly),
+            )
+        }
+    }
+
+    private fun showEditDialog(action: SettingsUiAction.ShowEditExpense) {
+        _uiState.update {
+            it.copy(
+                showExpenseDialog = true,
+                editingExpense = EditingExpense(
+                    id = action.id,
+                    name = action.name,
+                    amount = action.amount.toString(),
+                    icon = action.icon,
+                    isMonthly = action.isMonthly,
+                ),
+            )
+        }
+    }
+
+    private fun dismissDialog() {
+        _uiState.update { it.copy(showExpenseDialog = false, editingExpense = null) }
+    }
+
+    private fun saveExpense(expense: EditingExpense) {
+        viewModelScope.launch {
+            val amount = expense.amount.toLongOrNull() ?: 0L
+            val result = if (expense.isMonthly) {
+                saveMonthlyExpense(
+                    id = expense.id,
+                    name = expense.name,
+                    amount = amount,
+                    icon = expense.icon,
+                )
+            } else {
+                saveDailyExpense(
+                    id = expense.id,
+                    name = expense.name,
+                    amount = amount,
+                    icon = expense.icon,
+                )
+            }
+            result
+                .onSuccess { dismissDialog() }
+                .onFailure { error ->
+                    _uiEvent.emit(GlobalUiEvent.ShowSnackbar(error.message ?: "Gagal menyimpan"))
+                }
+        }
+    }
+
+    private fun deleteExpense(id: Long, isMonthly: Boolean) {
+        viewModelScope.launch {
+            runCatching {
+                if (isMonthly) settingsRepository.deleteMonthlyExpense(id)
+                else settingsRepository.deleteDailyExpense(id)
+            }.onSuccess {
+                _uiEvent.emit(GlobalUiEvent.ShowSnackbar("Berhasil dihapus"))
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/driverwallet/app/feature/settings/ui/ThemeViewModel.kt
+++ b/app/src/main/java/com/driverwallet/app/feature/settings/ui/ThemeViewModel.kt
@@ -1,0 +1,27 @@
+package com.driverwallet.app.feature.settings.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.driverwallet.app.feature.settings.domain.SettingsKeys
+import com.driverwallet.app.feature.settings.domain.SettingsRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+
+@HiltViewModel
+class ThemeViewModel @Inject constructor(
+    settingsRepository: SettingsRepository,
+) : ViewModel() {
+
+    val isDarkMode: StateFlow<Boolean> = settingsRepository
+        .observeSetting(SettingsKeys.DARK_MODE)
+        .map { it == "true" }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = false,
+        )
+}

--- a/app/src/main/java/com/driverwallet/app/feature/settings/ui/component/BudgetSection.kt
+++ b/app/src/main/java/com/driverwallet/app/feature/settings/ui/component/BudgetSection.kt
@@ -1,0 +1,62 @@
+package com.driverwallet.app.feature.settings.ui.component
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun BudgetSection(
+    budgetBbm: String,
+    budgetMakan: String,
+    budgetRokok: String,
+    budgetPulsa: String,
+    onBudgetChange: (category: String, value: String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.padding(horizontal = 16.dp)) {
+        Text(
+            text = "Budget Harian",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        BudgetField(label = "BBM", value = budgetBbm, category = "fuel", onChanged = onBudgetChange)
+        BudgetField(label = "Makan", value = budgetMakan, category = "food", onChanged = onBudgetChange)
+        BudgetField(label = "Rokok", value = budgetRokok, category = "cigarette", onChanged = onBudgetChange)
+        BudgetField(label = "Pulsa/Data", value = budgetPulsa, category = "phone", onChanged = onBudgetChange)
+    }
+}
+
+@Composable
+private fun BudgetField(
+    label: String,
+    value: String,
+    category: String,
+    onChanged: (String, String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    OutlinedTextField(
+        value = value,
+        onValueChange = { newValue ->
+            onChanged(category, newValue.filter { it.isDigit() })
+        },
+        label = { Text(label) },
+        prefix = { Text("Rp ") },
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+        singleLine = true,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp),
+    )
+}

--- a/app/src/main/java/com/driverwallet/app/feature/settings/ui/component/DarkModeToggle.kt
+++ b/app/src/main/java/com/driverwallet/app/feature/settings/ui/component/DarkModeToggle.kt
@@ -1,0 +1,52 @@
+package com.driverwallet.app.feature.settings.ui.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun DarkModeToggle(
+    isDarkMode: Boolean,
+    onToggle: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+            .semantics { contentDescription = "Toggle mode gelap" },
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = "\uD83C\uDF19",
+                style = MaterialTheme.typography.titleLarge,
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Text(
+                text = "Mode Gelap",
+                style = MaterialTheme.typography.bodyLarge,
+            )
+        }
+        Switch(
+            checked = isDarkMode,
+            onCheckedChange = onToggle,
+        )
+    }
+}

--- a/app/src/main/java/com/driverwallet/app/feature/settings/ui/component/ExpenseFormDialog.kt
+++ b/app/src/main/java/com/driverwallet/app/feature/settings/ui/component/ExpenseFormDialog.kt
@@ -1,0 +1,82 @@
+package com.driverwallet.app.feature.settings.ui.component
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.driverwallet.app.feature.settings.ui.EditingExpense
+
+@Composable
+fun ExpenseFormDialog(
+    expense: EditingExpense,
+    onDismiss: () -> Unit,
+    onSave: (EditingExpense) -> Unit,
+) {
+    var name by remember(expense) { mutableStateOf(expense.name) }
+    var amount by remember(expense) { mutableStateOf(expense.amount) }
+    val isEditing = expense.id != 0L
+    val typeLabel = if (expense.isMonthly) "Bulanan" else "Harian"
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(text = if (isEditing) "Edit Pengeluaran $typeLabel" else "Tambah Pengeluaran $typeLabel")
+        },
+        text = {
+            Column {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text("Nama") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = amount,
+                    onValueChange = { newValue ->
+                        amount = newValue.filter { it.isDigit() }
+                    },
+                    label = { Text("Jumlah") },
+                    prefix = { Text("Rp ") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    onSave(
+                        expense.copy(
+                            name = name,
+                            amount = amount,
+                        ),
+                    )
+                },
+                enabled = name.isNotBlank() && (amount.toLongOrNull() ?: 0L) > 0,
+            ) {
+                Text("Simpan")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Batal")
+            }
+        },
+    )
+}

--- a/app/src/main/java/com/driverwallet/app/feature/settings/ui/component/FixedExpenseSection.kt
+++ b/app/src/main/java/com/driverwallet/app/feature/settings/ui/component/FixedExpenseSection.kt
@@ -1,0 +1,141 @@
+package com.driverwallet.app.feature.settings.ui.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.driverwallet.app.core.util.CurrencyFormatter
+
+data class FixedExpenseDisplay(
+    val id: Long,
+    val name: String,
+    val icon: String,
+    val amount: Long,
+)
+
+@Composable
+fun FixedExpenseSection(
+    title: String,
+    expenses: List<FixedExpenseDisplay>,
+    onAdd: () -> Unit,
+    onEdit: (FixedExpenseDisplay) -> Unit,
+    onDelete: (Long) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.padding(horizontal = 16.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
+            TextButton(onClick = onAdd) {
+                Icon(
+                    Icons.Filled.Add,
+                    contentDescription = "Tambah",
+                    modifier = Modifier.size(18.dp),
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                Text("Tambah")
+            }
+        }
+        if (expenses.isEmpty()) {
+            Text(
+                text = "Belum ada data",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(vertical = 8.dp),
+            )
+        } else {
+            expenses.forEach { expense ->
+                ExpenseItem(
+                    expense = expense,
+                    onEdit = { onEdit(expense) },
+                    onDelete = { onDelete(expense.id) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ExpenseItem(
+    expense: FixedExpenseDisplay,
+    onEdit: () -> Unit,
+    onDelete: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        onClick = onEdit,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp),
+        shape = MaterialTheme.shapes.medium,
+        color = MaterialTheme.colorScheme.surfaceVariant,
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Surface(
+                shape = MaterialTheme.shapes.small,
+                color = MaterialTheme.colorScheme.primaryContainer,
+                modifier = Modifier.size(40.dp),
+            ) {
+                Text(
+                    text = when (expense.icon) {
+                        "payments" -> "\uD83D\uDCB3"
+                        "home" -> "\uD83C\uDFE0"
+                        "wifi" -> "\uD83D\uDCF6"
+                        "electric_bolt" -> "\u26A1"
+                        "water_drop" -> "\uD83D\uDCA7"
+                        else -> "\uD83D\uDCB0"
+                    },
+                    modifier = Modifier.padding(8.dp),
+                )
+            }
+            Spacer(modifier = Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = expense.name,
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Medium,
+                )
+                Text(
+                    text = "Rp ${CurrencyFormatter.format(expense.amount)}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            IconButton(onClick = onDelete) {
+                Icon(
+                    Icons.Filled.Delete,
+                    contentDescription = "Hapus ${expense.name}",
+                    tint = MaterialTheme.colorScheme.error,
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/driverwallet/app/feature/settings/ui/component/TargetDateRow.kt
+++ b/app/src/main/java/com/driverwallet/app/feature/settings/ui/component/TargetDateRow.kt
@@ -1,0 +1,112 @@
+package com.driverwallet.app.feature.settings.ui.component
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TargetDateRow(
+    targetDate: String,
+    onDateSelected: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var showPicker by remember { mutableStateOf(false) }
+
+    val displayDate = if (targetDate.isNotBlank()) {
+        runCatching {
+            java.time.LocalDate.parse(targetDate)
+                .format(DateTimeFormatter.ofPattern("d MMMM yyyy", Locale("id", "ID")))
+        }.getOrDefault(targetDate)
+    } else {
+        "Belum diatur"
+    }
+
+    Surface(
+        onClick = { showPicker = true },
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp),
+        shape = MaterialTheme.shapes.medium,
+        color = MaterialTheme.colorScheme.surfaceVariant,
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                Icons.Filled.DateRange,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "Target Tanggal Lunas",
+                    style = MaterialTheme.typography.bodyLarge,
+                )
+                Text(
+                    text = displayDate,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Icon(
+                Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = "Pilih tanggal",
+            )
+        }
+    }
+
+    if (showPicker) {
+        val datePickerState = rememberDatePickerState()
+        DatePickerDialog(
+            onDismissRequest = { showPicker = false },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        datePickerState.selectedDateMillis?.let { millis ->
+                            val date = Instant.ofEpochMilli(millis)
+                                .atZone(ZoneId.systemDefault())
+                                .toLocalDate()
+                            onDateSelected(date.toString())
+                        }
+                        showPicker = false
+                    },
+                ) { Text("OK") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showPicker = false }) { Text("Batal") }
+            },
+        ) {
+            DatePicker(state = datePickerState)
+        }
+    }
+}


### PR DESCRIPTION
## 🎯 What
Full settings screen: dark mode toggle, daily budgets, target date, monthly/daily fixed expenses.

## 🏗️ Architecture
```
UI (SettingsScreen) → ViewModel → UseCases → SettingsRepository → Room DAOs
```

## ✅ Tasks Completed

### Domain (4 files)
- [x] `SettingsKeys.kt` — `DARK_MODE`, `TARGET_DATE` constants
- [x] `SaveDailyBudgetsUseCase.kt` — validates amount ≥ 0, preserves existing IDs on upsert
- [x] `SaveMonthlyExpenseUseCase.kt` — validates name non-empty, amount > 0
- [x] `SaveDailyExpenseUseCase.kt` — same pattern

### State + ViewModel (3 files)
- [x] `SettingsUiState.kt` — UiState + EditingExpense + SettingsUiAction sealed interface
- [x] `SettingsViewModel.kt` — observe 5 flows, immediate dark mode, save-all action
- [x] `ThemeViewModel.kt` — bridge DataStore dark_mode → `DriverWalletTheme`

### UI Components (5 files)
- [x] `DarkModeToggle.kt` — M3 Switch, immediate persistence
- [x] `BudgetSection.kt` — 4x OutlinedTextField (BBM/Makan/Rokok/Pulsa) numeric-only
- [x] `TargetDateRow.kt` — Surface tap → DatePickerDialog → ISO date
- [x] `FixedExpenseSection.kt` — reusable for monthly & daily + FixedExpenseDisplay model
- [x] `ExpenseFormDialog.kt` — AlertDialog add/edit with validation

### Screen (1 file)
- [x] `SettingsScreen.kt` — LazyColumn + all sections + "Simpan Perubahan" button

## ⚠️ Note
- `ThemeViewModel` ready for integration in `MainActivity` (bridge `observeSetting("dark_mode")` → `DriverWalletTheme(darkTheme)`)
- Budget save preserves existing entity IDs to avoid unique constraint conflicts on `category`

Closes #9